### PR TITLE
Play Cast Animation directly in an Action.

### DIFF
--- a/raidsim/Assets/Scripts/Actions/CharacterActionData.cs
+++ b/raidsim/Assets/Scripts/Actions/CharacterActionData.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using NaughtyAttributes;
 using static GlobalData;
 
 [CreateAssetMenu(fileName = "New Character Action", menuName = "FFXIV/New Character Action")]
@@ -37,6 +38,8 @@ public class CharacterActionData : ScriptableObject
     public StatusEffectData debuff;
     public bool dispelDebuffInstead = false;
     public CharacterActionData comboAction;
+    public bool playCastingAnimationDirectly = false;
+    [ShowIf("playCastingAnimationDirectly")] public string castingAnimationName = string.Empty;
     public string animationName = string.Empty;
     public bool playAnimationDirectly = false;
     public bool playAnimationOnFinish = false;

--- a/raidsim/Assets/Scripts/Character/ActionController.cs
+++ b/raidsim/Assets/Scripts/Character/ActionController.cs
@@ -863,7 +863,14 @@ public class ActionController : MonoBehaviour
 
                 if (animator != null && !action.data.isGroundTargeted)
                 {
-                    animator.SetBool(animatorParameterCasting, true);
+                    if (action.data.playCastingAnimationDirectly)
+                    {
+                        animator.CrossFadeInFixedTime(action.data.castingAnimationName, 0.2f);
+                    }
+                    else
+                    {
+                        animator.SetBool(animatorParameterCasting, true);
+                    }
                 }
 
                 if (action.data.isGroundTargeted)


### PR DESCRIPTION
Very self-explanatory, adds two properties in `CharacterActionData` and uses it in `ActionController`:
The first added property is **playCastingAnimationDirectly**. If enabled, it plays the animation specified by **castingAnimationName**. Similar to how `animationName` works already.

To not break all previous existing actions, the default value of **playCastingAnimationDirectly** is **false**.